### PR TITLE
Aktualizované balíčky, pridaný .npmignore

### DIFF
--- a/IntraWeb/src/IntraWeb/Scripts/boot.ts
+++ b/IntraWeb/src/IntraWeb/Scripts/boot.ts
@@ -1,4 +1,6 @@
-﻿import {bootstrap} from 'angular2/platform/browser';
+﻿/// <reference path="../node_modules/angular2/typings/browser.d.ts" />
+
+import {bootstrap} from 'angular2/platform/browser';
 import {ROUTER_PROVIDERS} from 'angular2/router';
 import {AppComponent} from './components/app.component';
 

--- a/IntraWeb/src/IntraWeb/bower.json
+++ b/IntraWeb/src/IntraWeb/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "ASP.NET",
+  "name": "intraweb",
   "private": true,
   "dependencies": {
     "bootstrap": "3.3.5",

--- a/IntraWeb/src/IntraWeb/package.json
+++ b/IntraWeb/src/IntraWeb/package.json
@@ -1,23 +1,22 @@
 {
-  "name": "ASP.NET",
+  "name": "intraweb",
   "version": "0.0.0",
   "dependencies": {
-    "angular2": "^2.0.0-beta.0",
+    "angular2": "^2.0.0-beta.8",
     "es6-shim": "0.33.13",
-    "gulp-less": "^3.0.5",
-    "reflect-metadata": "^0.1.2",
-    "rxjs": "^5.0.0-beta.0",
-    "systemjs": "0.19.6",
-    "zone.js": "^0.5.10"
+    "reflect-metadata": "0.1.2",
+    "rxjs": "5.0.0-beta.2",
+    "systemjs": "0.19.23",
+    "zone.js": "0.5.15"
   },
   "devDependencies": {
-    "gulp": "3.8.11",
-    "gulp-concat": "2.5.2",
+    "gulp": "3.9.1",
+    "gulp-concat": "2.6.0",
     "gulp-cssmin": "0.1.7",
-    "gulp-uglify": "1.2.0",
+    "gulp-uglify": "1.5.3",
     "gulp-rimraf": "^0.2.0",
     "gulp-sass": "^2.2.0",
-    "gulp-typescript": "^2.10.0",
-    "rimraf": "2.2.8"
+    "gulp-typescript": "^2.12.1",
+    "rimraf": "2.5.2"
   }
 }

--- a/IntraWeb/src/IntraWeb/package.json
+++ b/IntraWeb/src/IntraWeb/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "dependencies": {
     "angular2": "^2.0.0-beta.8",
+    "es6-promise": "^3.0.2",
     "es6-shim": "0.33.13",
     "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.2",


### PR DESCRIPTION
Nefšímajte si názov vetvy. :smile:

- Aktualizované balíčky na najvyššiu verziu, tam kde to šlo. Niektoré musia ostať nižšie, lebo tak to vyžadujú závislosti.
- Pridaný prázdny súbor `.npmignore`.

Štvalo ma, že v logu pri sťahovaní balíčkov je kopec chýb a tak som okolo toho skúšal kadečo. A už som v stave, že keď vymažem celý node_modules adresár a dám nanovo stiahnuť, tak to je bez akejkoľvek chyby. Súbor `.npmignore` úplne presne neviem na čo slúži, ale **je potrebný**. Ak neexistuje, `npm` automaticky namiesto neho použije `.gitignore`. Niektoré chyby boli spôsobené tým, že nejaké veci `npm` na základe `.gitignore` odignoroval.