### PR TITLE
Oprava chyby #84 - padanie testov v AutoMapper-i

### DIFF
--- a/IntraWeb/src/IntraWeb/TestHelper.cs
+++ b/IntraWeb/src/IntraWeb/TestHelper.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+
+using AutoMapper;
+using AutoMapper.Mappers;
+
+namespace IntraWeb
+{
+    public static class TestHelper
+    {
+
+        /// <summary>
+        /// Creates a mapper for tests.
+        /// </summary>
+        /// <param name="configuration">Configuration of mapper.</param>
+        /// <returns>
+        /// <para>Unit tests are executed <b>in parallel</b>. beacuse of this, it is not possible to create a mapper
+        /// using standard way: <c>new new MapperConfiguration(Action&lt;IMapperConfiguration&gt;)</c>. Mapping objects with
+        /// such mappers throws an <c>InvalidOperationException</c>, because one thread is iterating inner <b>static</b>
+        /// list of mappers, while another thread tries to add to the same list. This method creates separate lists for
+        /// each returned mapper.</para>
+        /// </returns>
+        public static IMapper CreateMapper(Action<IMapperConfiguration> configuration)
+        {
+            var mapperConfig = new MapperConfiguration(
+                configuration,
+                new List<IObjectMapper>(MapperRegistry.Mappers),
+                new List<ITypeMapObjectMapper>(TypeMapObjectMapperRegistry.Mappers)
+            );
+
+            return mapperConfig.CreateMapper();
+        }
+
+    }
+}

--- a/IntraWeb/test/IntraWeb.UnitTests/Controllers/Api/v1/EquipmentsControllerTest.cs
+++ b/IntraWeb/test/IntraWeb.UnitTests/Controllers/Api/v1/EquipmentsControllerTest.cs
@@ -1,7 +1,12 @@
+using Microsoft.AspNet.Http.Internal;
+using Microsoft.AspNet.Mvc;
 using System;
 using System.Linq;
 using System.Net;
+
 using AutoMapper;
+using Xunit;
+
 using IntraWeb.Controllers.Api.v1;
 using IntraWeb.Filters;
 using IntraWeb.Models.Rooms;
@@ -9,9 +14,6 @@ using IntraWeb.Models.Rooms.Dummies;
 using IntraWeb.UnitTests.Filters;
 using IntraWeb.UnitTests.Service;
 using IntraWeb.ViewModels.Rooms;
-using Microsoft.AspNet.Http.Internal;
-using Microsoft.AspNet.Mvc;
-using Xunit;
 
 namespace IntraWeb.UnitTests.Controllers.Api.v1
 {
@@ -587,12 +589,10 @@ namespace IntraWeb.UnitTests.Controllers.Api.v1
 
         private IMapper CreateMapper()
         {
-            var config = new MapperConfiguration(cfg =>
+            return TestHelper.CreateMapper(cfg =>
             {
                 cfg.AddProfile<RoomsMappingProfile>();
             });
-
-            return config.CreateMapper();
         }
 
         #endregion

--- a/IntraWeb/test/IntraWeb.UnitTests/Controllers/Api/v1/RolesControllerTest.cs
+++ b/IntraWeb/test/IntraWeb.UnitTests/Controllers/Api/v1/RolesControllerTest.cs
@@ -1,16 +1,18 @@
-﻿using System;
-using System.Linq;
-using Xunit;
-using IntraWeb.UnitTests.Service;
+﻿using Microsoft.AspNet.Http.Internal;
 using Microsoft.AspNet.Mvc;
-using Microsoft.AspNet.Http.Internal;
+using System;
+using System.Linq;
 using System.Net;
-using IntraWeb.UnitTests.Filters;
-using IntraWeb.Filters;
-using IntraWeb.Controllers.Api.v1;
-using IntraWeb.ViewModels.Users;
-using IntraWeb.Models.Users;
+
 using AutoMapper;
+using Xunit;
+
+using IntraWeb.Controllers.Api.v1;
+using IntraWeb.Filters;
+using IntraWeb.Models.Users;
+using IntraWeb.UnitTests.Filters;
+using IntraWeb.UnitTests.Service;
+using IntraWeb.ViewModels.Users;
 
 namespace IntraWeb.UnitTests.Controllers.Api.v1
 {
@@ -59,7 +61,7 @@ namespace IntraWeb.UnitTests.Controllers.Api.v1
                 });
             });
 
-            // Act 
+            // Act
             var roles = target.Get().ToList();
 
             // Assert
@@ -580,12 +582,10 @@ namespace IntraWeb.UnitTests.Controllers.Api.v1
 
         private IMapper CreateMapper()
         {
-            var config = new MapperConfiguration(cfg =>
+            return TestHelper.CreateMapper(cfg =>
             {
                 cfg.AddProfile<UsersMappingProfile>();
             });
-
-            return config.CreateMapper();
         }
 
         #endregion

--- a/IntraWeb/test/IntraWeb.UnitTests/Controllers/Api/v1/RoomsControllerTest.cs
+++ b/IntraWeb/test/IntraWeb.UnitTests/Controllers/Api/v1/RoomsControllerTest.cs
@@ -1,18 +1,20 @@
-﻿using System;
-using System.Linq;
-using Xunit;
-using IntraWeb.UnitTests.Service;
+﻿using Microsoft.AspNet.Http.Internal;
 using Microsoft.AspNet.Mvc;
-using Microsoft.AspNet.Http.Internal;
-using System.Net;
-using IntraWeb.UnitTests.Filters;
-using IntraWeb.Filters;
-using IntraWeb.Controllers.Api.v1;
-using IntraWeb.Models.Rooms;
-using IntraWeb.ViewModels.Rooms;
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+
 using AutoMapper;
+using Xunit;
+
+using IntraWeb.Controllers.Api.v1;
+using IntraWeb.Filters;
+using IntraWeb.Models.Rooms;
 using IntraWeb.Models.Rooms.Dummies;
+using IntraWeb.UnitTests.Filters;
+using IntraWeb.UnitTests.Service;
+using IntraWeb.ViewModels.Rooms;
 
 namespace IntraWeb.UnitTests.Controllers.Api.v1
 {
@@ -687,12 +689,10 @@ namespace IntraWeb.UnitTests.Controllers.Api.v1
 
         private IMapper CreateMapper()
         {
-            var config = new MapperConfiguration(cfg =>
+            return TestHelper.CreateMapper(cfg =>
             {
                 cfg.AddProfile<RoomsMappingProfile>();
             });
-
-            return config.CreateMapper();
         }
 
         #endregion

--- a/IntraWeb/test/IntraWeb.UnitTests/Controllers/Api/v1/UsersControllerTest.cs
+++ b/IntraWeb/test/IntraWeb.UnitTests/Controllers/Api/v1/UsersControllerTest.cs
@@ -1,17 +1,19 @@
-﻿using System;
-using System.Linq;
-using Xunit;
-using IntraWeb.UnitTests.Service;
+﻿using Microsoft.AspNet.Http.Internal;
 using Microsoft.AspNet.Mvc;
-using Microsoft.AspNet.Http.Internal;
-using System.Net;
-using IntraWeb.UnitTests.Filters;
-using IntraWeb.Filters;
-using IntraWeb.Controllers.Api.v1;
-using IntraWeb.ViewModels.Users;
-using IntraWeb.Models.Users;
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+
 using AutoMapper;
+using Xunit;
+
+using IntraWeb.Controllers.Api.v1;
+using IntraWeb.Filters;
+using IntraWeb.Models.Users;
+using IntraWeb.UnitTests.Filters;
+using IntraWeb.UnitTests.Service;
+using IntraWeb.ViewModels.Users;
 
 namespace IntraWeb.UnitTests.Controllers.Api.v1
 {
@@ -760,12 +762,10 @@ namespace IntraWeb.UnitTests.Controllers.Api.v1
 
         private IMapper CreateMapper()
         {
-            var config = new MapperConfiguration(cfg =>
+            return TestHelper.CreateMapper(cfg =>
             {
                 cfg.AddProfile<UsersMappingProfile>();
             });
-
-            return config.CreateMapper();
         }
 
         #endregion


### PR DESCRIPTION
Mappery vytvárané klasickým spôsobom new `new MapperConfiguration(Action<IMapperConfiguration>)` interne používajú dva statické zoznamy. Keď testy bežia paralelne, stane sa, že pri mapovaní jedno vlákno iteruje cez jeden zo zoznamov a druhé vlákno sa do toho istého zoznamu snaží niečo pridať. Preto testy padajú na výnimke `InvalidOperationException`.

Vytvoril som pomocnú triedu `TestHelper`, kde je metóda na vytváranie mapperov, ktoré nepoužívajú statické zoznamy, ale každý vytvorený mapper má svoje. Príslušné testy si mapper vytvárajú pomocou nej.